### PR TITLE
Okta support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM macadmins/crypt-server:latest
 MAINTAINER Graham Gilbert <graham@grahamgilbert.com>
-ENV DJANGO_SAML_VERSION 0.14.4
+ENV DJANGO_SAML_VERSION 0.15.0
 
 RUN apt-get update && apt-get install -y python-setuptools python-dev libxmlsec1-dev libxml2-dev xmlsec1 \
     && easy_install pip \

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ A Docker container for Crypt Server that uses SAML
 
 You will almost certainly need to edit `settings.py` and provide your own metadata.xml file from your SAML provider.
 
+_The following instructions are provided as a best effort to help get started. They might require modifications to meet specific environments._
+
 ## settings.py changes you will certainly need to make
 - `SAML_ATTRIBUTE_MAPPING` (These values come from OpenLDAP, Active Directory, etc)
 - `SAML_CONFIG`
@@ -29,13 +31,31 @@ macadmins/crypt-server-saml:2.2.0
 ```
 
 ## Notes on OneLogin
-Your Onelogin `Configuration` should have the minimum settings
-- `Recipient` Ex: https://crypt.example.com/saml2/acs/
-- `ACS (Consumer) URL Validator` Ex: .*
-- `ACS (Consumer) URL`Ex: https://crypt.example.com/saml/acs/
+1. In the OneLogin admin portal click on Apps > Add Apps.
+1. Search for `SAML Test Connector (IdP)`. Click on this option.
+1. Give the application a display name, upload a icon if you wish, and then click save.
+1. Under "Configuration" tab, you will need at least the minimum settings shown below:
+    * `Recipient`: https://crypt.example.com/saml2/acs/
+    * `ACS (Consumer) URL Validator`: .*  (Note this is a period followed by an asterisk)
+    * `ACS (Consumer) URL`: https://crypt.example.com/saml2/acs/
+1. Under the "Parameters" tab, you will need to add the custom iDP Fields/Values. The process looks like:
+    * Click "Add parameter"
+      - `Field name`: FIELD_NAME
+      - `Flags`: Check the Include in SAML assertion
+    * Now click on the created field and set the appropriate FIELD_VALUE based on the table below.
 
-You will also need to configure your `Parameters` section with the custom iDP Fields/Values.
-- Ensure these fields are passed in the SAML Assertion
+    Repeat the above steps for all required fields:
+
+    | **FIELD_NAME** | **FIELD_VALUE**   |
+    |-----------|--------------|
+    | urn:mace:dir:attribute-def:cn   | First Name      |
+    | urn:mace:dir:attribute-def:sn   | Last Name       |
+    | urn:mace:dir:attribute-def:mail | Email           |
+    | urn:mace:dir:attribute-def:uid  | Email name part |
+
+1. Under the "SSO" tab, download the "Issuer URL" metadata file. This will be mounted in your docker container [(see above)](#an-example-docker-run).
+1. Under the "SSO" tab, you will find the "SAML 2.0 Endpoint" and "SLO Endpoint" which will go into the `settings.py` > `idp` section.
+1. Lastly, "Save" the SAML Test Connector (IdP).
 
 
 ## Notes on Okta
@@ -52,7 +72,7 @@ Okta has a slightly different implementation and a few of the tools that this co
 
     Single sign on URL: **https://crypt.example.com/saml2/acs/**
     Use this for Recipient URL and Destination URL: **Checked**
-    Allow this app to request other SSO URLs: **Unchecked**
+    Allow this app to request other SSO URLs: **Unchecked** (If this option is available)
     Audience URI (SP Entity ID): **https://crypt.example.com/saml2/metadata/**
     Default RelayState:
     Default RelayState: **Unspecified**

--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@ A Docker container for Crypt Server that uses SAML
 
 You will almost certainly need to edit `settings.py` and provide your own metadata.xml file from your SAML provider.
 
-### settings.py changes you will certainly need to make
+## settings.py changes you will certainly need to make
 - `SAML_ATTRIBUTE_MAPPING` (These values come from OpenLDAP, Active Directory, etc)
 - `SAML_CONFIG`
-  - `entityid` Ex: https://crypt.domain.tld/saml2/metadata/
-  - `assertion_consumer_service` Ex: https://crypt.domain.tld/saml2/acs/
-  - `single_logout_service` Ex: https://crypt.domain.tld/saml2/ls/ and https://crypt.domain.tld/saml2/post
+  - `entityid` Ex: https://crypt.example.com/saml2/metadata/
+  - `assertion_consumer_service` Ex: https://crypt.example.com/saml2/acs/
+  - `single_logout_service` Ex: https://crypt.example.com/saml2/ls/ and https://crypt.example.com/saml2/post
   - `required_attributes` - These should match the values from SAML_ATTRIBUTE_MAPPING
   - `idp`
     - `root url` Ex: https://app.onelogin.com/saml/metadata/1234567890
     - `single_sign_on_service` Ex: https://apps.onelogin.com/trust/saml2/http-post/sso/1234567890
     - `single_logout_service` Ex: https://apps.onelogin.com/trust/saml2/http-redirect/slo/1234567890
 
-### An example Docker run
+## An example Docker run
 
 Please note that this docker run is **incomplete**, but shows where to pass the `metadata.xml` and `settings.py`
 
@@ -28,13 +28,56 @@ docker run -d --name="crypt" \
 macadmins/crypt-server-saml:2.2.0
 ```
 
-### Notes on OneLogin
+## Notes on OneLogin
 Your Onelogin `Configuration` should have the minimum settings
-- `Recipient` Ex: https://crypt.domain.tld/saml2/acs/
+- `Recipient` Ex: https://crypt.example.com/saml2/acs/
 - `ACS (Consumer) URL Validator` Ex: .*
-- `ACS (Consumer) URL`Ex: https://crypt.domain.tld/saml/acs/
+- `ACS (Consumer) URL`Ex: https://crypt.example.com/saml/acs/
 
 You will also need to configure your `Parameters` section with the custom iDP Fields/Values.
 - Ensure these fields are passed in the SAML Assertion
+
+
+## Notes on Okta
+Okta has a slightly different implementation and a few of the tools that this container uses, specifically [`pysaml2`](https://github.com/rohe/pysaml2) and [`djangosaml2`](https://github.com/knaperek/djangosaml2), do not like this implementation by default. Please follow the setup instructions, make sure to replace the example URL:
+1. Create a new app from the admin portal
+
+    Platform: Web
+    Sign on method: SAML 2.0
+
+1. Under "General Settings", give the app a name, add a logo and modify app visibility as desired.
+1. Under "Configure SAML" enter the following (if no value is given after the colon leave it blank):
+
+    #### General
+
+    Single sign on URL: **https://crypt.example.com/saml2/acs/**
+    Use this for Recipient URL and Destination URL: **Checked**
+    Allow this app to request other SSO URLs: **Unchecked**
+    Audience URI (SP Entity ID): **https://crypt.example.com/saml2/metadata/**
+    Default RelayState:
+    Default RelayState: **Unspecified**
+    Application username: **Okta username**
+
+    #### Attribute Statements
+
+    | **Name** | **Format** | **Value** |
+    |-----------|-----------|-----------|
+    | urn:mace:dir:attribute-def:cn   | Basic | ${user.firstName} |
+    | urn:mace:dir:attribute-def:sn   | Basic | ${user.lastName}  |
+    | urn:mace:dir:attribute-def:mail | Basic | ${user.email}     |
+    | urn:mace:dir:attribute-def:uid  | Basic | ${user.login}     |
+
+    #### Group Attribute Statements
+
+    crypt does not support these at this time.
+
+1. Under "Feedback":
+
+    Are you a customer or partner? I'm an Okta customer adding an internal app
+    App type: This is an internal app that we have created
+
+Now that Okta is setup you will need to modify your settings.py to match. Note if you used the Attribute Statements above you should not have to modify the `SAML_ATTRIBUTE_MAPPING` variable. The metadata file can be downloaded from the Application's "Sign On" tab > Settings > SAML 2.0 > "Identity Provider metadata" link. The `idp` URLs are found under the "Sign On" > Settings > SAML 2.0 > "View Setup Instructions" button.
+
+# Help
 
 For more information on what to put in your settings.py, look at https://github.com/knaperek/djangosaml2

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please note that this docker run is **incomplete**, but shows where to pass the 
 docker run -d --name="crypt" \
 -p 80:8000 \
 -v /yourpath/metadata.xml:/home/docker/crypt/fvserver/metadata.xml \
--v /yourpath/settings.py:/home/docker/crypt/fvserver//settings.py \
+-v /yourpath/settings.py:/home/docker/crypt/fvserver/settings.py \
 --restart="always" \
 macadmins/crypt-server-saml:2.2.0
 ```

--- a/settings.py
+++ b/settings.py
@@ -125,7 +125,7 @@ SAML_CONFIG = {
               # present in our metadata
 
               # the keys of this dictionary are entity ids
-              'https://YOURID:' {
+              'https://YOURID': {
                   'single_sign_on_service': {
                       saml2.BINDING_HTTP_REDIRECT: 'https://YOURSSOURL',
                       },

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,5 @@
 # Django settings for Crypt project.
-from settings_import import ADMINS, TIME_ZONE, LANGUAGE_CODE, ALLOWED_HOSTS, DISPLAY_NAME, DEBUG
+from settings_import import *
 from system_settings import *
 from os import path
 import saml2
@@ -78,7 +78,7 @@ SAML_CONFIG = {
   'xmlsec_binary': '/usr/bin/xmlsec1',
 
   # your entity id, usually your subdomain plus the url to the metadata view
-  'entityid': 'http://YOU/saml2/metadata/',
+  'entityid': 'https://crypt.example.com/saml2/metadata/',
 
   # directory with attribute mapping
   'attribute_map_dir': path.join(BASEDIR, 'attributemaps'),
@@ -97,16 +97,16 @@ SAML_CONFIG = {
               # url and binding to the assetion consumer service view
               # do not change the binding or service name
               'assertion_consumer_service': [
-                  ('http://YOU/saml2/acs/',
+                  ('https://crypt.example.com/saml2/acs/',
                    saml2.BINDING_HTTP_POST),
                   ],
               # url and binding to the single logout service view
               # do not change the binding or service name
               'single_logout_service': [
-                  ('http://YOU/saml2/ls/',
+                  ('https://crypt.example.com/saml2/ls/',
                    saml2.BINDING_HTTP_REDIRECT),
 
-                  ('http://YOU/saml2/ls/post',
+                  ('https://crypt.example.com/saml2/ls/post',
                    saml2.BINDING_HTTP_POST),
                   ],
               },

--- a/settings.py
+++ b/settings.py
@@ -1,11 +1,12 @@
 # Django settings for Crypt project.
 from settings_import import *
-from system_settings import *
+# from system_settings import *  # Not currently implemented with Crypt
 from os import path
 import saml2
 from saml2.saml import NAMEID_FORMAT_PERSISTENT
 import logging
 import sys
+import os
 
 PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.pardir))
 
@@ -40,7 +41,7 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': os.path.join(PROJECT_DIR, 'db/sal.db'),                      # Or path to database file if using sqlite3.
+        'NAME': os.path.join(PROJECT_DIR, 'db/crypt.db'),                      # Or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
@@ -53,11 +54,11 @@ host = None
 port = None
 
 if os.environ.has_key('DB_HOST'):
-    host = os.environ('DB_HOST')
+    host = os.environ.get('DB_HOST')
     port = os.environ.get('DB_PORT')
 
 elif os.environ.has_key('DB_PORT_5432_TCP_ADDR'):
-    host = os.environ('DB_PORT_5432_TCP_ADDR')
+    host = os.environ.get('DB_PORT_5432_TCP_ADDR')
     port = os.environ.get('DB_PORT_5432_TCP_PORT', '5432')
 
 if host and port:

--- a/settings.py
+++ b/settings.py
@@ -125,7 +125,7 @@ SAML_CONFIG = {
               # present in our metadata
 
               # the keys of this dictionary are entity ids
-              'https://YOURID: {
+              'https://YOURID:' {
                   'single_sign_on_service': {
                       saml2.BINDING_HTTP_REDIRECT: 'https://YOURSSOURL',
                       },


### PR DESCRIPTION
Same thing as the sal-saml container. This adds Okta support. So that I didn't create merge conflicts I've pre-merged @erikng's two open PRs. Thus merging this one PR will merge all open requests for this repo.

This updates `djangosaml2` to 0.15.0 to support okta without crashing. I've also updated the docs and changed all sample URLs to sal.example.com so it is easier to follow the README and settings.py, plus we can now do a find all and replace.

I've also created a temporary [test container](https://hub.docker.com/r/clburlison/crypt-server-saml-test):
repo: `clburlison/crypt-server-saml-test`
tag: `2.2.0-okta`

I have **not** tested this update with OneLogin or Okta at this time.